### PR TITLE
Add common Maven build workflow

### DIFF
--- a/.github/maven.yml
+++ b/.github/maven.yml
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: GitHub CI
+
+on: workflow_call
+  inputs:
+    maven_args:
+      description: The arguments to pass to Maven when building the code
+      required: false
+      default: --batch-mode --errors --show-version verify
+      type: string
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest,windows-latest, macOS-latest ]
+        java: [ 8, 11, 16, 17 ]
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn ${{ inputs.maven_args }}


### PR DESCRIPTION
Testing with the latest version of version requires regular update to all Plexus repositories' GitHub Actions workflows. This is a repetitive, time consuming task.

Given that the build workflow for the various Plexus project is almost the same, we can re-use common workflow. Then using the latest version of Java is just a matter of changing the build matrix in single file.

This proposal makes use of the new reusable workflows feature - https://docs.github.com/en/actions/learn-github-actions/reusing-workflows. What do you think? Also what about the default maven args - is this sensible default?