### PR TITLE
Update build matrix for the Maven build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,7 +47,7 @@ on:
       jdk-distribution-matrix:
         description: "jdk distribution matrix"
         required: false
-        default: '[ "temurin", "adopt" ]'
+        default: '[ "temurin" ]'
         type: string
         
       jdk-fast-fail-build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "8", "11", "17" ]'
+        default: '[ "8", "11", "17", "18-ea" ]'
         type: string
 
       matrix-exclude:


### PR DESCRIPTION
I've added 18-ea as it is the upcoming version of JDK and it is nice to test with it as well. 

I've removed AdoptJDK as it seems it is moved to Eclipse Temurin so, unless I'm missing something, they are essentially the same. If we want second JDK we can use some of the other distributions out there.