### PR TITLE
Use only stable jdks per default

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "8", "11", "17", "18" ]'
+        default: '[ "8", "11", "17" ]'
         type: string
 
       matrix-exclude:


### PR DESCRIPTION
projects can configure more it they need to do so.