### PR TITLE
Switch to Zulu and update build matrix up to JDK 19

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "8", "11", "17" ]'
+        default: '[ "8", "11", "17", "18", "19-ea" ]'
         type: string
 
       matrix-exclude:
@@ -47,7 +47,7 @@ on:
       jdk-distribution-matrix:
         description: "jdk distribution matrix"
         required: false
-        default: '[ "temurin" ]'
+        default: '[ "zulu" ]'
         type: string
         
       jdk-fast-fail-build:
@@ -70,7 +70,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ inputs.jdk-fast-fail-build }}
-          distribution: 'temurin'
+          distribution: 'zulu'
           cache: 'maven'
 
       - name: Build with Maven


### PR DESCRIPTION
Zulu provides larger set of JDK versions, including early access(EA) versions. Any objections to switch to it instead of Temurin? Only Oracle JDK (but I'm not sure anymore what is free and what not) and SAP Machine (not as popular) provide larger set of versions (including 20, which is the release after the next at time of writing).

The upcoming version is 19 - include the EA version in order to test our projects before the release.