### PR TITLE
Add JDK 20 EA to the build matrix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "8", "11", "17", "19" ]'
+        default: '[ "8", "11", "17", "19", "20-ea" ]'
         type: string
 
       matrix-exclude:


### PR DESCRIPTION
JDK 20 is going to be released soon. We should tests with the early release version. Any objections?