### PR TITLE
Use JDK 20 GA instead of EA

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -35,7 +35,7 @@ on:
       jdk-matrix:
         description: 'jdk matrix as json array'
         required: false
-        default: '[ "8", "11", "17", "19", "20-ea" ]'
+        default: '[ "8", "11", "17", "20" ]'
         type: string
 
       matrix-exclude:


### PR DESCRIPTION
As now JDK 20 is GA use it instead of EA version.

Remove JDK 19 as it is STS version and the latest STS now is 20.