### PR TITLE
Correct the release procedure in RELEASING.md: publishing is automatic

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -31,7 +31,13 @@ mvn release:prepare
 mvn release:perform
 ```
 
-`release:prepare` tags and bumps versions; `release:perform` builds from the tag and stages to the Central Portal. Then publish the staged deployment from the Central Portal UI.
+`release:prepare` tags and bumps versions; `release:perform` builds from the tag and deploys.
+
+There is no manual publish step. `maven-release-plugin` is configured in the parent with `<goals>deploy</goals>` and `<releaseProfiles>plexus-release</releaseProfiles>`, so `release:perform` activates the `plexus-release` profile. That profile adds GPG signing, attaches sources and a source-release assembly, and sets `njord.enabled=true`.
+
+[Njord](https://maveniverse.eu/docs/njord/) is registered as a build extension and configured with `autoPublish=true` and `publishingType=automatic`, so it publishes the deployment to Central itself. `njord.enabled` is `false` outside the release profile, so ordinary builds are unaffected.
+
+Releasing needs Maven **3.9.0** or later — the `plexus-release` profile raises `minimalMavenBuildVersion` above the 3.6.3 required for a normal build.
 
 Afterwards:
 


### PR DESCRIPTION
Follow-up to #60, which I got wrong. Part of #58.

`RELEASING.md` says:

> `release:perform` builds from the tag and stages to the Central Portal. Then publish the staged deployment from the Central Portal UI.

There is no such manual step.

`maven-release-plugin` is configured in the parent POM with `<goals>deploy</goals>` and `<releaseProfiles>plexus-release</releaseProfiles>`. The `plexus-release` profile sets `njord.enabled=true`, and [Njord](https://maveniverse.eu/docs/njord/) is registered as a build extension with:

```xml
<njord.publisher>sonatype-cp</njord.publisher>
<njord.autoPublish>true</njord.autoPublish>
<njord.publishingType>automatic</njord.publishingType>
```

So `release:perform` publishes to Central by itself. `njord.enabled` is `false` outside the release profile, so normal builds are unaffected.

Telling a release manager to go and finish the job in the Portal UI would have them looking for something that isn't there — which is a worse failure than saying nothing, so worth fixing promptly now that #60 is merged.

Also adds that releasing needs **Maven 3.9.0**: `plexus-release` raises `minimalMavenBuildVersion` from the 3.6.3 an ordinary build needs, so a release run on 3.6.x fails the enforcer.

I found this while documenting the parent POM itself (codehaus-plexus/plexus-pom#438), which describes the same mechanism from the other side.