### PR TITLE
Add a manually-triggered site publishing workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Publish Site
+
+on:
+  workflow_call:
+    inputs:
+      multi-module:
+        description: 'Stage the site before publishing. Required for reactors with modules.'
+        required: false
+        default: false
+        type: boolean
+
+      dry-run:
+        description: 'Build and check out gh-pages, but do not commit or push.'
+        required: false
+        default: false
+        type: boolean
+
+      maven_args:
+        description: 'Goals and arguments used to build the site'
+        required: false
+        default: '--batch-mode --errors --show-version -Preporting clean verify'
+        type: string
+
+      maven-version:
+        description: 'The Maven version used to build the site'
+        required: false
+        default: '3.9.11'
+        type: string
+
+      jdk-version:
+        description: 'JDK used to build the site'
+        required: false
+        default: '21'
+        type: string
+
+      jdk-distribution:
+        description: 'JDK distribution used to build the site'
+        required: false
+        default: 'temurin'
+        type: string
+
+# one publish at a time: two concurrent runs would race on gh-pages
+concurrency:
+  group: publish-site-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  publish-site:
+    name: Publish Site
+
+    if: github.repository_owner == 'codehaus-plexus'
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      # maven-scm-publish-plugin commits the generated site to the gh-pages branch
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ inputs.jdk-version }}
+          distribution: ${{ inputs.jdk-distribution }}
+          cache: 'maven'
+
+      - name: Set up Maven
+        run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper "-Dtype=only-script" "-Dmaven=${{ inputs.maven-version }}"
+
+      - name: Configure git
+        # The POMs set pubScmUrl from scm.developerConnection, which is an ssh URL and
+        # cannot authenticate here. Rewrite it to https and let the job token supply the
+        # credential, so the token stays out of the command line and the process list.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global "url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf" "https://github.com/"
+
+      - name: Publish site
+        run: |
+          ./mvnw ${{ inputs.maven_args }} \
+            ${{ inputs.multi-module && 'site site:stage scm-publish:publish-scm' || 'site-deploy' }} \
+            "-Dscmpublish.pubScmUrl=scm:git:https://github.com/${{ github.repository }}.git" \
+            "-Dscmpublish.scm.branch=gh-pages" \
+            "-Dscmpublish.dryRun=${{ inputs.dry-run }}" \
+            "-Dscmpublish.checkinComment=Site checkin for ${{ github.repository }}@${{ github.sha }}"


### PR DESCRIPTION
Part of #58. The last item on the plan.

Site publishing is entirely manual today and was documented differently in six READMEs, two of which contradicted their own POM. That shows up in the `gh-pages` dates, which ranged from **May 2023 to June 2026** before this effort started. This gives every project one button.

### Deliberately `workflow_dispatch`, not release-triggered

I raised this earlier on #58 and it still seems right: publishing on release puts unreviewed content live automatically, takes the release manager out of the loop, and Maven site builds break often enough — doxia, site plugin, JDK interactions — that I would rather a person saw the output. This makes the procedure repeatable without making it unattended.

Easy to promote to release-triggered later if it proves boring.

### The authentication problem, and how this solves it

The POMs derive `pubScmUrl` from `scm.developerConnection`, which is:

```
scm:git:ssh://git@github.com:codehaus-plexus/plexus-utils.git
```

An ssh URL cannot authenticate with the job token, so the plugin would fail. The workflow overrides it to https and supplies the credential through a git rewrite rule:

```yaml
git config --global "url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf" "https://github.com/"
```

That keeps the token out of the command line and the process list, which passing `-Dscmpublish.pubScmUrl=https://token@…` would not. Checkout runs with `persist-credentials: false`.

**No new secret is needed** — `permissions: contents: write` on the job is enough for the token to push to that repository's own `gh-pages`.

### Handles both project layouts

| | Goals | `content` |
|---|---|---|
| single-module (10 repos) | `site-deploy` | `target/site`, set in each POM |
| multi-module (4 repos) | `site site:stage scm-publish:publish-scm` | `target/staging` — the plugin default |

I checked the plugin descriptor rather than assuming: `content` defaults to `${project.build.directory}/staging`, which is exactly what `site:stage` produces. So the `multi-module` input switches goals and needs no other configuration.

Property names are from the plugin descriptor too — `scmpublish.pubScmUrl`, `scmpublish.scm.branch`, `scmpublish.content`, `scmpublish.dryRun`.

### `dry-run`

Builds the site and checks out `gh-pages` without committing or pushing. The first use of this in any repository should be a dry run.

### Concurrency

`cancel-in-progress: false`, grouped per repository. Two concurrent runs would race on `gh-pages`, and cancelling one mid-push is worse than queueing.

### Callers come next

Once this merges, each repository needs a small caller. I'll do two first so the shape can be reviewed before the sweep:

```yaml
name: Publish Site
on:
  workflow_dispatch:
jobs:
  site:
    uses: codehaus-plexus/.github/.github/workflows/site.yml@master
```

and for the multi-module ones:

```yaml
    with:
      multi-module: true
```

That is `modello`, `plexus-compiler`, `plexus-languages` and `plexus-interactivity`.

Note this cannot be end-to-end tested until it is on `master`, since `workflow_call` resolves against a ref — which is the other reason for the `dry-run` input.