### PR TITLE
Unify the label taxonomy across the org

### DIFF
--- a/.github/labels.tsv
+++ b/.github/labels.tsv
@@ -1,0 +1,24 @@
+# Canonical label set for codehaus-plexus repositories
+# name<TAB>color<TAB>description
+#
+# Colour rule: a hue carries meaning, and any two labels that appear side by
+# side must differ in BOTH hue and text colour (GitHub picks white or black by
+# brightness). Same-hue ramps of three are unreadable at label-pill size, so
+# each hue gets at most two steps: one dark/white-text, one light/black-text.
+breaking	B60205	Backwards-incompatible change
+removed	D93F0B	Removed API, feature or module
+deprecated	E99695	Deprecated API or feature
+bug	D73A4A	Something isn't working
+enhancement	0E8A16	New feature or improvement
+documentation	0075CA	Documentation and site content
+maintenance	FBCA04	Cleanup, refactoring, internal change
+build	795548	Build, CI and release infrastructure
+dependencies	0366D6	Dependency update (applied by Dependabot)
+java	FFA221	Maven/Java dependency update (applied by Dependabot)
+github_actions	79B8FF	GitHub Actions update (applied by Dependabot)
+help wanted	008672	Extra attention is needed
+good first issue	7057FF	Good for newcomers
+question	D876E3	Further information is requested
+need-rebase	D4C5F9	Branch has conflicts and needs a rebase before it can merge
+no-changelog	CFD3D7	Deliberately excluded from the release notes
+reverted	24292F	Change was reverted; excluded from the release notes

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,66 +1,51 @@
-# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
+# Configuration for Release Drafter: https://github.com/release-drafter/release-drafter
+# Shared by every codehaus-plexus repo via `_extends: .github`.
+#
+# Every label referenced here exists in labels.tsv, and every label in
+# labels.tsv either has a category here or is deliberately excluded.
+# Note that `categories` is an array: a repo that overrides it via _extends
+# replaces the whole array rather than appending to it.
 name-template: $NEXT_PATCH_VERSION
 tag-template: $NEXT_PATCH_VERSION
 version-template: $MAJOR.$MINOR.$PATCH
 
-# Emoji reference: https://gitmoji.carloscuesta.me/
 categories:
   - title: ":boom: Breaking changes"
-    labels: 
-      - breaking
+    labels: [breaking]
   - title: 🚨 Removed
-    labels:
-      - removed
-  - title: ":tada: Major features and improvements"
-    labels:
-      - major-enhancement
-      - major-rfe
-  - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
+    labels: [removed]
   - title: ⚠️ Deprecated
-    labels:
-      - deprecated
+    labels: [deprecated]
   - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
-      - rfe
+    labels: [enhancement]
   - title: 🐛 Bug Fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
-  - title: ":construction_worker: Changes for plugin developers"
-    labels:
-      - developer 
+    labels: [bug]
   - title: 📝 Documentation updates
-    labels:
-      - documentation
+    labels: [documentation]
   - title: 👻 Maintenance
-    labels: 
-      - chore
-      - internal
-      - maintenance
+    labels: [maintenance]
   - title: 🔧 Build
-    labels:
-      - build
-  - title: 🚦 Tests
-    labels: 
-      - test
-      - tests
-  # Default label used by Dependabot
+    labels: [build]
+  # Applied automatically by Dependabot. This is ~85% of all labelled items in
+  # the org, so it is collapsed behind a summary line rather than being allowed
+  # to bury every other category.
   - title: 📦 Dependency updates
-    labels:
-      - dependencies
-      - dependency
-      - dependency-upgrade
+    labels: [dependencies]
+    collapse-after: 10
+
 exclude-labels:
   - reverted
   - no-changelog
-  - skip-changelog
-  - invalid
+
+# Derive the next version from the labels already being applied.
+version-resolver:
+  major:
+    labels: [breaking]
+  minor:
+    labels: [enhancement, removed, deprecated]
+  patch:
+    labels: [bug, documentation, maintenance, build, dependencies]
+  default: patch
 
 change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
 

--- a/.github/sync-labels.sh
+++ b/.github/sync-labels.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Sync the canonical codehaus-plexus label set across all active repositories.
+#
+#   ./sync-labels.sh            # dry run  - print what would change
+#   ./sync-labels.sh --apply    # create/update the canonical labels
+#   ./sync-labels.sh --apply --prune   # ... and fold the superseded ones away
+#
+# Deletion policy: a label is only ever deleted after every issue and PR
+# carrying it has been moved onto its replacement, or if it was never used at
+# all. Deleting a label in GitHub strips it from every past issue permanently
+# and there is no undo, so labels that carry history and have no replacement
+# (java8, hacktoberfest-accepted, wontfix, invalid) are left in place. They are
+# simply no longer propagated to repos that don't already have them.
+#
+set -uo pipefail
+
+DEF="$(dirname "$0")/labels.tsv"
+APPLY=0; PRUNE=0
+for a in "$@"; do
+  case "$a" in --apply) APPLY=1 ;; --prune) PRUNE=1 ;; esac
+done
+
+REPOS=(
+  plexus-archiver plexus-build-api plexus-classworlds plexus-compiler
+  plexus-i18n plexus-interactivity plexus-interpolation plexus-io
+  plexus-languages plexus-pom plexus-resources plexus-sec-dispatcher
+  plexus-testing plexus-utils plexus-velocity plexus-xml
+  modello .github codehaus-plexus.github.io
+)
+
+# superseded label -> canonical replacement
+declare -A MERGE=(
+  [fix]=bug
+  [bugfix]=bug
+  [chore]=maintenance
+  [internal]=maintenance
+  [plugins]=dependencies
+)
+
+# labels to remove only if they are provably unused (0 issues, 0 PRs)
+DROP_IF_UNUSED=(TASK duplicate test)
+
+run() { if [ "$APPLY" = 1 ]; then "$@"; else echo "  DRY: $*"; fi; }
+
+DRIFT=0
+
+# Compare a repo's live labels against the canonical file and print only the
+# differences, so a dry run is a drift report rather than a list of every label.
+report_drift() {
+  local R="$1" live name color desc have_color have_desc
+  live=$(gh label list -R "$R" --limit 200 --json name,color,description \
+           --jq '.[] | [.name, (.color|ascii_upcase), (.description // "")] | @tsv')
+  while IFS=$'\t' read -r name color desc; do
+    [[ -z "$name" || "$name" == \#* ]] && continue
+    local row; row=$(grep -F -m1 "$(printf '%s\t' "$name")" <<<"$live")
+    if [ -z "$row" ]; then
+      echo "  MISSING: $name"; DRIFT=1; continue
+    fi
+    have_color=$(cut -f2 <<<"$row"); have_desc=$(cut -f3 <<<"$row")
+    if [ "$have_color" != "$(tr '[:lower:]' '[:upper:]' <<<"$color")" ]; then
+      echo "  COLOUR:  $name is #$have_color, expected #$color"; DRIFT=1
+    fi
+    if [ "$have_desc" != "$desc" ]; then
+      echo "  DESC:    $name description differs"; DRIFT=1
+    fi
+  done < "$DEF"
+}
+
+has_label() {
+  gh label list -R "$1" --limit 200 --json name --jq '.[].name' | grep -qxF "$2"
+}
+
+# every issue and PR number carrying $2 in repo $1
+tagged() {
+  gh issue list -R "$1" --state all --label "$2" --limit 500 --json number --jq '.[].number'
+  gh pr    list -R "$1" --state all --label "$2" --limit 500 --json number --jq '.[].number'
+}
+
+for repo in "${REPOS[@]}"; do
+  R="codehaus-plexus/$repo"
+  echo "=== $R"
+
+  # 1. create or recolour the canonical set
+  if [ "$APPLY" = 1 ]; then
+    while IFS=$'\t' read -r name color desc; do
+      [[ -z "$name" || "$name" == \#* ]] && continue
+      gh label create "$name" -R "$R" --color "$color" --description "$desc" --force
+    done < "$DEF"
+  else
+    report_drift "$R"
+  fi
+
+  [ "$PRUNE" = 1 ] || continue
+
+  # 2. fold superseded labels into their replacement, then delete the empty definition
+  for old in "${!MERGE[@]}"; do
+    has_label "$R" "$old" || continue
+    new="${MERGE[$old]}"
+    for n in $(tagged "$R" "$old"); do
+      run gh issue edit "$n" -R "$R" --add-label "$new" --remove-label "$old"
+    done
+    run gh label delete "$old" -R "$R" --yes
+  done
+
+  # 3. delete leftovers only when nothing references them
+  for old in "${DROP_IF_UNUSED[@]}"; do
+    has_label "$R" "$old" || continue
+    if [ -z "$(tagged "$R" "$old")" ]; then
+      run gh label delete "$old" -R "$R" --yes
+    else
+      echo "  KEEP: $old is in use in $R - not deleting"
+    fi
+  done
+done
+
+# exit non-zero when a dry run found drift, so CI can gate on it
+[ "$APPLY" = 1 ] || exit $DRIFT

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,0 +1,58 @@
+# Re-applies .github/labels.tsv to every active repo in the org.
+#
+# This exists because the label set drifted badly once already: `maintenance`
+# ended up defined in 18 repos with 18 different colours, because there was a
+# convention but nothing that enforced it. Fixing the state without fixing the
+# process just resets the clock.
+#
+# Runs in report-only mode by default: the weekly run prints what has drifted
+# and fails if anything has, so the divergence is visible without anything
+# being changed behind a maintainer's back. Dispatch it manually with
+# apply = true to actually re-apply.
+#
+# REQUIRES a repository secret named LABEL_SYNC_TOKEN: a fine-grained PAT with
+# read/write on Issues for the codehaus-plexus repos. The default GITHUB_TOKEN
+# is scoped to this repository alone and cannot write labels to the others, so
+# without that secret this workflow can only fail. It is intentionally left to
+# a maintainer with org admin to create.
+name: Label sync
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply the canonical labels (otherwise report only)'
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check the token is configured
+        env:
+          GH_TOKEN: ${{ secrets.LABEL_SYNC_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::LABEL_SYNC_TOKEN is not set. See the comment at the top of this workflow."
+            exit 1
+          fi
+
+      - name: Sync labels
+        env:
+          GH_TOKEN: ${{ secrets.LABEL_SYNC_TOKEN }}
+        run: |
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            .github/sync-labels.sh --apply
+          else
+            .github/sync-labels.sh | tee drift.log
+            if grep -q '^  DRY:' drift.log; then
+              echo "::warning::Labels have drifted from .github/labels.tsv - see the log above."
+            fi
+          fi


### PR DESCRIPTION
Part of #58.

I surveyed the labels across the 19 active repos before touching anything: 246 label definitions, and 5,514 label applications across all issues and PRs. Two problems came out of it.

**The colours were never coordinated.** `maintenance` exists in 18 repos with **18 different random hex colours** — `#02570C`, `#47F4DD`, `#EC4614`, `#240C22` and so on. `build` is in 6 repos with 6 different colours, `breaking` 5 with 5, `chore` 3 with 3. Same label, same meaning, different colour in every repo. On top of that, 14 repos still carry the pre-2018 GitHub default palette with no descriptions (`bug #fc2929`, `enhancement #84b6eb`); only 4 have the current one.

**The shared release-drafter config had drifted from reality.** It categorises on 24 labels, of which **13 exist in no repo in the org**: `major-enhancement`, `major-rfe`, `major-bug`, `feature`, `rfe`, `regression`, `developer`, `test`, `deprecated`, `dependency`, `dependency-upgrade`, `skip-changelog`. Those categories can never match. Meanwhile `maintenance` — the third most-used label in the org at 222 uses — was reachable only through the `chore`/`internal` aliases that nobody applies.

Usage is very concentrated. Six labels are 92% of all applications:

| label | uses | | label | uses |
|---|---|---|---|---|
| `dependencies` | 2366 | | `documentation` | 20 |
| `java` | 1801 | | `help wanted` | 17 |
| `github_actions` | 503 | | `build` | 16 |
| `enhancement` | 323 | | `breaking` | 11 |
| `maintenance` | 222 | | everything else | ≤9 each |
| `bug` | 187 | | `TASK`, `duplicate`, `good first issue` | 0 |

## What this PR does

**`labels.tsv`** — the canonical set, 17 labels. The colour rule is that hue carries meaning, and **any two labels that can appear side by side must differ in both hue and text colour** (GitHub picks white or black from brightness). A three-step same-hue ramp is unreadable at pill size, so each hue gets at most two steps.

| family | labels | reading |
|---|---|---|
| red | `breaking` `removed` `deprecated` `bug` | something is broken or going away |
| green / blue / amber / brown | `enhancement` `documentation` `maintenance` `build` | kind of change |
| blue + amber + light blue | `dependencies` `java` `github_actions` | applied by Dependabot |
| green / purple | `help wanted` `good first issue` `question` `need-rebase` | needs a human |
| grey | `no-changelog` `reverted` | invisible to the release notes |

`dependencies` keeps `#0366D6` and `java` keeps `#FFA221` — Dependabot's own defaults. Those two co-occur on roughly 1,800 Maven PRs and sit side by side in every list, so they are deliberately opposite (dark blue/white text against amber/black text) rather than two steps of one blue.

**`sync-labels.sh`** — applies the file to every repo. Dry run is a genuine **drift report**: it diffs live labels against the file, prints only what differs, and exits non-zero if anything does. `--apply` reconciles. `--prune` folds superseded labels away.

**`release-drafter.yml`** — rewritten so config and labels agree. Every label it references exists, and every label that exists has a category or is deliberately excluded. Two additions beyond the cleanup:

- `collapse-after: 10` on the dependencies category. That category is ~85% of all labelled items; without this it buries every other section of every release note.
- a `version-resolver` — `breaking` → major, `enhancement`/`removed`/`deprecated` → minor, everything else → patch. Free semver hygiene from labels we are standardising anyway.

Both keys validated against release-drafter's own `schema.json` at v7.7.0, which is the version our workflow pins.

**`workflows/label-sync.yml`** — the part that stops this happening again. The 18-random-colours situation arose because there was a convention and nothing enforcing it; fixing the state without fixing the process just resets the clock.

The weekly run is **report-only and needs no credentials.** Every plexus repo is public, and reading labels from a public repo requires no permissions at all, so the default `GITHUB_TOKEN` is enough — I verified this with an unauthenticated request. It diffs live labels against `labels.tsv` and fails if they've drifted. The schedule never changes anything.

Reconciling (`apply: true`) does need write access, via an optional `LABEL_SYNC_TOKEN` secret — a fine-grained PAT owned by the org with `Issues: Read and write`. **Only an org owner can add that secret; I'm a member, not an owner.** Until one exists the drift report still works, and anyone with push rights can reconcile by running `.github/sync-labels.sh --apply` locally, which is exactly how the current state was applied. So this workflow is useful on day one and gets better if an owner later adds the secret — it is never a permanently-red job.

## Already applied

The colour/description half is live on all 19 repos so you can look at it rather than imagine it. **Create-and-recolour only — nothing deleted, no issue relabelled.** `good first issue` also went from 4 repos to all 19, which matters for anyone arriving from outside.

## Deliberately held back

Retiring the leftovers is in `--prune` and has not been run: `fix`/`bugfix` → `bug`, `chore`/`internal` → `maintenance`, `plugins` → `dependencies`, and deleting `TASK` and `duplicate` (0 uses each).

**Labels with real history are not deleted at all.** Deleting a label in GitHub strips it from every past issue permanently, with no undo. So `java8` (6 uses), `hacktoberfest-accepted` (2 — and that exact name is what Hacktoberfest keys on if the org ever opts in again), `invalid` and `wontfix` stay defined where they carry history; they are simply no longer propagated. `--prune` also refuses to delete anything still in use, and migrates issues onto the replacement before removing a merged label.

## Changes made after review

A reviewer went through this and found four things worth correcting, all folded in above:

- **`java` at `#1D76DB` was the worst decision in the original proposal.** It made the two labels that co-occur on ~1,800 Dependabot PRs into near-identical blues. Reverted to Dependabot's amber `#FFA221`.
- **Two collisions I had missed**: `build #006B75` against `help wanted #008672` (both dark teal, indistinguishable), and `need-rebase #A371F7` against `good first issue #7057FF`. `build` moved to brown `#795548`, `need-rebase` to `#D4C5F9`. `help wanted` and `good first issue` keep GitHub's defaults because its contributor-discovery surfaces key on them.
- **`no-changelog` at `#EDEDED` is near-invisible against GitHub's white background.** Moved to `#CFD3D7`, with `reverted` at near-black `#24292F`.
- **`test` is cut.** Not merely unused — the shared config has advertised a `test` category for years and no repo ever grew the label. That is a finished experiment, not an untried idea. `deprecated` stays despite 0 uses: for a library org, deprecations are API-lifecycle events consumers need to see in release notes.
- **`wontfix` dropped from the canonical set**, for consistency: I was deleting `duplicate` and `invalid` as superseded by GitHub's native close reasons, and *close as not planned* supersedes `wontfix` by exactly the same argument. It keeps its definition where it has history.
