### PR TITLE
Take the publish branch from the POM, not the workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -93,6 +93,11 @@ jobs:
         # The POMs set pubScmUrl from scm.developerConnection, which is an ssh URL and
         # cannot authenticate here. Rewrite it to https and let the job token supply the
         # credential, so the token stays out of the command line and the process list.
+        #
+        # Only pubScmUrl is overridden. The target branch comes from the POM: the parent
+        # sets gh-pages, and codehaus-plexus.github.io overrides it to master because an
+        # organisation page is served from there. Forcing gh-pages here would silently
+        # publish that site to a branch nobody serves.
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -105,6 +110,5 @@ jobs:
           ./mvnw ${{ inputs.maven_args }} \
             ${{ inputs.multi-module && 'site site:stage scm-publish:publish-scm' || 'site-deploy' }} \
             "-Dscmpublish.pubScmUrl=scm:git:https://github.com/${{ github.repository }}.git" \
-            "-Dscmpublish.scm.branch=gh-pages" \
             "-Dscmpublish.dryRun=${{ inputs.dry-run }}" \
             "-Dscmpublish.checkinComment=Site checkin for ${{ github.repository }}@${{ github.sha }}"


### PR DESCRIPTION
Found while adding the caller to `codehaus-plexus.github.io`, which is the one repository that breaks the assumption.

The workflow forces the publish branch:

```
"-Dscmpublish.scm.branch=gh-pages"
```

That is correct for project sites. It is **wrong for the organisation page**: `codehaus-plexus.github.io` is served from `master`, not `gh-pages` —

```
$ gh api repos/codehaus-plexus/codehaus-plexus.github.io/pages
"source": { "branch": "master", "path": "/" }
```

— and its POM already says so:

```xml
<!-- see https://help.github.com/articles/user-organization-and-project-pages/ -->
<scmBranch>master</scmBranch>
```

The `-D` would have overridden that and published the main site to a branch nobody serves. The build would have **succeeded**, so the only symptom would have been the site quietly never updating.

The fix is to stop overriding it. Parent 26 sets `<scmBranch>gh-pages</scmBranch>` in `pluginManagement`, so every project site targets exactly what it did before, and the one repository that needs something different already declares it. That is the same principle already applied to `content`, which the workflow also leaves to the POM.

My mistake in #62 — I generalised from the fourteen project sites and did not check the org page.