### PR TITLE
Push the site with git instead of maven-scm-publish-plugin

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -32,6 +32,12 @@ on:
         default: false
         type: boolean
 
+      publish-branch:
+        description: 'Branch the built site is committed to. gh-pages for project sites; master for the organisation page.'
+        required: false
+        default: 'gh-pages'
+        type: string
+
       maven_args:
         description: 'Goals and arguments used to build the site'
         required: false
@@ -89,26 +95,63 @@ jobs:
       - name: Set up Maven
         run: mvn --errors --batch-mode --show-version org.apache.maven.plugins:maven-wrapper-plugin:3.2.0:wrapper "-Dtype=only-script" "-Dmaven=${{ inputs.maven-version }}"
 
-      - name: Configure git
-        # The POMs set pubScmUrl from scm.developerConnection, which is an ssh URL and
-        # cannot authenticate here. Rewrite it to https and let the job token supply the
-        # credential, so the token stays out of the command line and the process list.
-        #
-        # Only pubScmUrl is overridden. The target branch comes from the POM: the parent
-        # sets gh-pages, and codehaus-plexus.github.io overrides it to master because an
-        # organisation page is served from there. Forcing gh-pages here would silently
-        # publish that site to a branch nobody serves.
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --global "url.https://x-access-token:${GH_TOKEN}@github.com/.insteadOf" "https://github.com/"
+      - name: Build site
+        run: ./mvnw ${{ inputs.maven_args }} ${{ inputs.multi-module && 'site site:stage' || 'site' }}
 
       - name: Publish site
+        # maven-scm-publish-plugin is not used to do the push here. The POMs configure
+        # its pubScmUrl explicitly, which means an explicitly configured value always
+        # wins over the -Dscmpublish.pubScmUrl user property, so the ssh URL from
+        # scm.developerConnection cannot be overridden from the command line - and ssh
+        # cannot authenticate with the job token. Pushing with git directly keeps the
+        # whole step under the workflow's control.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ inputs.publish-branch }}
+          DRY_RUN: ${{ inputs.dry-run }}
+          CONTENT: ${{ inputs.multi-module && 'target/staging' || 'target/site' }}
         run: |
-          ./mvnw ${{ inputs.maven_args }} \
-            ${{ inputs.multi-module && 'site site:stage scm-publish:publish-scm' || 'site-deploy' }} \
-            "-Dscmpublish.pubScmUrl=scm:git:https://github.com/${{ github.repository }}.git" \
-            "-Dscmpublish.dryRun=${{ inputs.dry-run }}" \
-            "-Dscmpublish.checkinComment=Site checkin for ${{ github.repository }}@${{ github.sha }}"
+          set -euo pipefail
+
+          if [ ! -d "$CONTENT" ]; then
+            echo "::error::the site build produced no $CONTENT directory"
+            exit 1
+          fi
+
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          if git ls-remote --exit-code --heads "$remote" "$BRANCH" >/dev/null 2>&1; then
+            git clone --branch "$BRANCH" --depth 1 --quiet "$remote" .site-publish
+          else
+            echo "branch $BRANCH does not exist yet; creating it"
+            git clone --depth 1 --quiet "$remote" .site-publish
+            git -C .site-publish checkout --orphan "$BRANCH"
+            git -C .site-publish rm -rq --cached . || true
+            find .site-publish -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          fi
+
+          # mirror the built site over the branch content, so pages deleted upstream
+          # also disappear from the published site
+          rsync -a --delete --exclude '.git' "$CONTENT"/ .site-publish/
+
+          cd .site-publish
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "site is unchanged; nothing to publish"
+            exit 0
+          fi
+
+          git status --short | head -50
+          echo "$(git diff --cached --name-only | wc -l) file(s) changed"
+
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "::notice::dry run - not committing or pushing"
+            exit 0
+          fi
+
+          git commit -qm "Site checkin for ${GITHUB_REPOSITORY}@${GITHUB_SHA}"
+          git push --quiet origin "$BRANCH"
+          echo "::notice::published to $BRANCH"


### PR DESCRIPTION
The first real run failed, on codehaus-plexus.github.io:

```
[INFO] Checking out the pub tree from scm:git:git@github.com:codehaus-plexus/codehaus-plexus.github.io.git
[INFO] Executing: git clone --branch master 'slachiewicz:********@github.com:codehaus-plexus/...'
[ERROR] ssh: Could not resolve hostname slachiewicz: Temporary failure in name resolution
```

### Why my approach could never have worked

The workflow passed `-Dscmpublish.pubScmUrl=…https…` to force an https URL. The plugin ignored it and used the ssh URL from `scm.developerConnection`.

That is Maven plugin parameter precedence: the parent POM sets

```xml
<pubScmUrl>${project.scm.developerConnection}</pubScmUrl>
```

**explicitly** in `<configuration>`, and an explicitly configured value always beats the `${scmpublish.pubScmUrl}` user property. So the `-D` was silently discarded — no warning, no error, just the wrong URL. This would have failed identically in all fifteen repositories; the org page was simply the first one tried.

Good argument for the `dry-run` input, which is how this surfaced without anything being published.

### The fix

Maven still builds the site — that part was never the problem. Only the push changes:

1. clone the target branch with the job token over https
2. `rsync -a --delete` the built site over it, so pages deleted upstream disappear from the published site too, which is what `scm-publish` did for us
3. commit and push, or, on a dry run, print what would change and stop

No plugin URL resolution involved, and every step is readable in the workflow.

### `publish-branch` input

This also replaces #65, which I opened an hour ago to make the branch come from the POM. That was the right instinct — the org page is served from `master`, not `gh-pages` — but the wrong mechanism, since the workflow now does the push itself and cannot read `scmBranch` out of the POM.

So it is an explicit input, defaulting to `gh-pages`. `codehaus-plexus.github.io` passes `master`. #65 is superseded; I'll close it.

### Unexplained, and now moot

The clone URL came out as `slachiewicz:********@github.com:` — maven-scm injected a username from somewhere I could not identify on a clean runner. It does not matter under the new approach, but I am flagging it rather than pretending I understood it.

### Please dry-run again after merging

Callers need no change except `codehaus-plexus.github.io`, which needs `publish-branch: master` — I'll update that PR.
