### PR TITLE
Do not let the change listing kill the publish step

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -144,8 +144,14 @@ jobs:
             exit 0
           fi
 
-          git status --short | head -50
-          echo "$(git diff --cached --name-only | wc -l) file(s) changed"
+          # sed rather than head: head exits after 50 lines, which SIGPIPEs git status,
+          # and under `set -o pipefail` that aborts the whole step with exit 141
+          changed=$(git diff --cached --name-only | wc -l)
+          git status --short | sed -n '1,50p'
+          if [ "$changed" -gt 50 ]; then
+            echo "... and $((changed - 50)) more"
+          fi
+          echo "$changed file(s) changed"
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "::notice::dry run - not committing or pushing"


### PR DESCRIPTION
The first run that got past authentication failed at the very last hurdle, on plexus-utils:

```
M  apidocs/org/codehaus/plexus/util/StringUtils.html
M  apidocs/org/codehaus/plexus/util/SweeperPool.html
...
##[error]Process completed with exit code 141
```

**141 is SIGPIPE**, and it is my bug, in this line:

```bash
git status --short | head -50
```

`head` exits after 50 lines. `git status` is then killed writing to a closed pipe. Under `set -o pipefail` that becomes the pipeline's exit status, and `set -e` makes it fatal.

Reproduced exactly:

```
$ bash -c 'set -euo pipefail; seq 1 500000 | head -50 >/dev/null'   # exit 141
$ bash -c 'set -euo pipefail; seq 1 500000 | sed -n "1,50p" >/dev/null'  # exit 0
```

It only bites when the output exceeds the pipe buffer, so this would have published a small site perfectly well and failed on a large one — plexus-utils regenerates thousands of apidocs files. A nastier failure mode than a consistent one.

The fix uses `sed`, which reads to end of input instead of exiting early, and says how many files were omitted from the listing.

### The good news

**Nothing was published, and everything before this worked.** The step died before the commit, and the log shows the clone, the token authentication and the rsync all succeeded — the run had a fully populated `gh-pages` checkout with the new site staged. So the approach in #66 is sound; this is the last thing between it and a working publish.

Worth saying plainly: two failed runs, both mine, both found by actually running it rather than by reading it. The `dry-run` input has paid for itself twice now.
